### PR TITLE
Create dark theme BeaverPhone dialpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/beaverphone.html
+++ b/beaverphone.html
@@ -1,60 +1,634 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>BeaverPhone</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
+    :root {
+      color-scheme: dark;
+      --bg: #060608;
+      --panel: #0f1018;
+      --panel-glow: rgba(248, 148, 34, 0.12);
+      --border: rgba(255, 255, 255, 0.08);
+      --text-main: #ffffff;
+      --text-muted: rgba(255, 255, 255, 0.64);
+      --text-soft: rgba(255, 255, 255, 0.42);
+      --accent: #f89422;
+      --accent-strong: #ff9f33;
+      --font: "Inter", "Segoe UI", sans-serif;
+      --shadow: 0 28px 40px rgba(0, 0, 0, 0.45);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
     body {
-      font-family: sans-serif;
-      background: #000;
-      color: #fff;
+      min-height: 100vh;
       display: flex;
       justify-content: center;
       align-items: center;
-      height: 100vh;
+      font-family: var(--font);
+      background: radial-gradient(circle at 15% 20%, rgba(248, 148, 34, 0.12), transparent 55%),
+        radial-gradient(circle at 85% 10%, rgba(248, 148, 34, 0.08), transparent 50%),
+        var(--bg);
+      color: var(--text-main);
+      padding: 3.5rem 2rem;
     }
-    .dialpad {
+
+    .beaverphone {
+      width: min(1200px, 100%);
       display: grid;
-      grid-template-columns: repeat(3, 80px);
+      gap: 2.6rem;
+    }
+
+    header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    header .eyebrow {
+      letter-spacing: 0.26em;
+      text-transform: uppercase;
+      font-size: 0.76rem;
+      font-weight: 600;
+      color: var(--text-soft);
+    }
+
+    header h1 {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      font-weight: 700;
+    }
+
+    header p {
+      color: var(--text-muted);
+      max-width: 640px;
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+
+    .app {
+      display: grid;
+      gap: 2.4rem;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 26px;
+      padding: 2.2rem;
+      box-shadow: var(--shadow);
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+    }
+
+    .panel::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: var(--panel-glow);
+      opacity: 0;
+      transition: opacity 180ms ease;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .panel:focus-within::after,
+    .panel:hover::after {
+      opacity: 1;
+    }
+
+    .dialpad-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      align-items: center;
+      margin-bottom: 1.8rem;
+    }
+
+    .dialpad-header h2 {
+      font-size: 1.35rem;
+      font-weight: 600;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.35rem 0.9rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      background: rgba(255, 255, 255, 0.02);
+      transition: border 160ms ease, color 160ms ease;
+    }
+
+    .status-pill[data-active="true"] {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .composer {
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+      border-radius: 20px;
+      padding: 1.2rem 1.4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+      margin-bottom: 1.6rem;
+    }
+
+    .composer label {
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--text-soft);
+      font-weight: 600;
+    }
+
+    .composer input {
+      background: transparent;
+      border: none;
+      color: inherit;
+      font-size: clamp(1.8rem, 4vw, 2.4rem);
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      outline: none;
+      width: 100%;
+    }
+
+    .composer input::placeholder {
+      color: rgba(255, 255, 255, 0.22);
+    }
+
+    .dialpad-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 1rem;
     }
-    button {
-      font-size: 1.5rem;
-      padding: 1rem;
-      border-radius: 8px;
-      border: none;
-      background: #333;
-      color: #fff;
+
+    .dialpad-key {
+      appearance: none;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 22px;
+      background: rgba(255, 255, 255, 0.03);
+      color: inherit;
+      padding: 1.1rem 0;
+      font-size: 1.75rem;
+      font-weight: 600;
+      text-align: center;
       cursor: pointer;
+      transition: transform 120ms ease, border 160ms ease, box-shadow 160ms ease;
+      position: relative;
     }
-    button:hover {
-      background: #f89422;
+
+    .dialpad-key span {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.25em;
+      color: var(--text-soft);
+      margin-top: 0.35rem;
+    }
+
+    .dialpad-key:active,
+    .dialpad-key:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent-strong);
+      box-shadow: 0 10px 20px rgba(248, 148, 34, 0.18);
+    }
+
+    .dialpad-actions,
+    .dialpad-secondary {
+      margin-top: 1.6rem;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .dialpad-secondary {
+      margin-top: 0.75rem;
+    }
+
+    .pill-btn {
+      appearance: none;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.02);
+      color: var(--text-muted);
+      font-weight: 600;
+      padding: 0.9rem 1.2rem;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: border 160ms ease, color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .pill-btn[data-active="true"] {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: rgba(248, 148, 34, 0.12);
+      box-shadow: 0 10px 18px rgba(248, 148, 34, 0.25);
+    }
+
+    .pill-btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .call-btn {
+      border-radius: 26px;
+      font-size: 1.1rem;
+      padding-block: 1.1rem;
+      background: linear-gradient(135deg, rgba(248, 148, 34, 0.95), rgba(248, 148, 34, 0.65));
+      color: #121212;
+      border: none;
+      box-shadow: 0 18px 32px rgba(248, 148, 34, 0.35);
+      position: relative;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .call-btn[data-active="true"] {
+      background: linear-gradient(135deg, rgba(248, 34, 34, 0.95), rgba(248, 34, 34, 0.7));
+      color: #fff;
+      box-shadow: 0 18px 32px rgba(248, 34, 34, 0.35);
+    }
+
+    .subtext {
+      font-size: 0.95rem;
+      color: var(--text-soft);
+      margin-top: 0.6rem;
+      text-align: center;
+    }
+
+    .extensions {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .extensions header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+
+    .extensions header h2 {
+      font-size: 1.35rem;
+      font-weight: 600;
+    }
+
+    .extensions header p {
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    .extension-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .extension-card {
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 20px;
+      background: rgba(255, 255, 255, 0.03);
+      padding: 1.35rem 1.4rem;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      align-items: center;
+      gap: 1.4rem;
+      cursor: pointer;
+      transition: transform 160ms ease, border 160ms ease, box-shadow 160ms ease;
+    }
+
+    .extension-card:hover {
+      transform: translateY(-3px);
+      border-color: var(--accent);
+      box-shadow: 0 12px 26px rgba(248, 148, 34, 0.18);
+    }
+
+    .extension-card .badge {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: rgba(248, 148, 34, 0.14);
+      color: var(--accent);
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+    }
+
+    .extension-card h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-bottom: 0.2rem;
+    }
+
+    .extension-card .subtitle {
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .extension-card .details {
+      color: var(--text-soft);
+      font-size: 0.82rem;
+      margin-top: 0.4rem;
+    }
+
+    .extension-card .extension {
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: 0.1em;
+    }
+
+    .empty-hint {
+      text-align: center;
+      color: var(--text-soft);
+      margin-top: 0.8rem;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 960px) {
+      body {
+        padding: 2rem 1.4rem;
+      }
+
+      .app {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
 <body>
-  <div class="dialpad">
-    <button onclick="dial('1')">1</button>
-    <button onclick="dial('2')">2</button>
-    <button onclick="dial('3')">3</button>
-    <button onclick="dial('4')">4</button>
-    <button onclick="dial('5')">5</button>
-    <button onclick="dial('6')">6</button>
-    <button onclick="dial('7')">7</button>
-    <button onclick="dial('8')">8</button>
-    <button onclick="dial('9')">9</button>
-    <button onclick="dial('*')">*</button>
-    <button onclick="dial('0')">0</button>
-    <button onclick="dial('#')">#</button>
+  <div class="beaverphone">
+    <header>
+      <span class="eyebrow">BeaverPhone</span>
+      <h1>Dial a number or choose an extension</h1>
+      <p>Connect instantly with community partners and internal contacts. Compose a number below or tap a contact to
+        begin.</p>
+    </header>
+
+    <div class="app">
+      <section class="panel" aria-labelledby="dialpad-heading">
+        <div class="dialpad-header">
+          <h2 id="dialpad-heading">Dialpad</h2>
+          <span class="status-pill" id="status-pill" data-active="false">Ready</span>
+        </div>
+
+        <div class="composer">
+          <label for="composer-input">Composer</label>
+          <input id="composer-input" type="text" inputmode="tel" autocomplete="off" placeholder="Tap numbers to dial"
+            aria-live="polite" />
+        </div>
+
+        <div class="dialpad-grid" id="dialpad"></div>
+
+        <div class="dialpad-actions">
+          <button type="button" class="pill-btn" id="erase-btn">Erase</button>
+          <button type="button" class="pill-btn call-btn" id="call-btn">Call</button>
+          <button type="button" class="pill-btn" id="speaker-btn">Speaker</button>
+        </div>
+
+        <div class="dialpad-secondary">
+          <button type="button" class="pill-btn" id="hold-btn" disabled>Hold</button>
+          <button type="button" class="pill-btn" id="clear-btn">Clear</button>
+          <span></span>
+        </div>
+
+        <p class="subtext" id="helper-text">Tap digits or choose a contact to start dialing.</p>
+      </section>
+
+      <aside class="panel extensions" aria-labelledby="extension-heading">
+        <header>
+          <h2 id="extension-heading">Extensions</h2>
+          <p>Tap a contact to call automatically.</p>
+        </header>
+        <div class="extension-list" id="extension-list"></div>
+      </aside>
+    </div>
   </div>
 
-  <script>
-    function dial(num) {
-      const event = new CustomEvent("beaverphone:dialpad", {
-        detail: { number: num }
+  <script type="module">
+    const BEAVERPHONE_DIALPAD_EVENT_KEY = "beaverphone:dialpad";
+
+    const currentDialpadState = {
+      dialedNumber: "",
+      isOnCall: false,
+      isOnHold: false,
+      isSpeakerEnabled: false,
+    };
+
+    const beaverPhoneConfig = {
+      dialpad: [
+        { label: "1" },
+        { label: "2", subtext: "ABC" },
+        { label: "3", subtext: "DEF" },
+        { label: "4", subtext: "GHI" },
+        { label: "5", subtext: "JKL" },
+        { label: "6", subtext: "MNO" },
+        { label: "7", subtext: "PQRS" },
+        { label: "8", subtext: "TUV" },
+        { label: "9", subtext: "WXYZ" },
+        { label: "*" },
+        { label: "0", subtext: "+" },
+        { label: "#" },
+      ],
+      contacts: [
+        {
+          name: "Ontario Provincial Police",
+          subtitle: "Internal line",
+          details: "Office 101",
+          extension: "1201",
+        },
+        {
+          name: "SPCA Niagara",
+          subtitle: "Paws Law",
+          details: "Office 3434",
+          extension: "3434",
+        },
+        {
+          name: "Mom",
+          subtitle: "Mom",
+          details: "Complaints Office",
+          extension: "22",
+        },
+        {
+          name: "Services Ontario",
+          subtitle: "Government of Ontario",
+          details: "Desktop *1345",
+          extension: "1345",
+        },
+      ],
+      dialpadEventKey: BEAVERPHONE_DIALPAD_EVENT_KEY,
+    };
+
+    const dialpadEl = document.getElementById("dialpad");
+    const composerInput = document.getElementById("composer-input");
+    const statusPill = document.getElementById("status-pill");
+    const helperText = document.getElementById("helper-text");
+    const callBtn = document.getElementById("call-btn");
+    const holdBtn = document.getElementById("hold-btn");
+    const speakerBtn = document.getElementById("speaker-btn");
+    const eraseBtn = document.getElementById("erase-btn");
+    const clearBtn = document.getElementById("clear-btn");
+    const extensionList = document.getElementById("extension-list");
+
+    const dispatchDialpadEvent = (number) => {
+      const event = new CustomEvent(beaverPhoneConfig.dialpadEventKey, {
+        detail: { number },
       });
       window.dispatchEvent(event);
+    };
+
+    const updateUI = () => {
+      composerInput.value = currentDialpadState.dialedNumber;
+      callBtn.dataset.active = currentDialpadState.isOnCall;
+      callBtn.textContent = currentDialpadState.isOnCall ? "End" : "Call";
+      holdBtn.disabled = !currentDialpadState.isOnCall;
+      holdBtn.dataset.active = currentDialpadState.isOnHold;
+      speakerBtn.dataset.active = currentDialpadState.isSpeakerEnabled;
+
+      if (currentDialpadState.isOnCall) {
+        statusPill.dataset.active = "true";
+        statusPill.textContent = currentDialpadState.isOnHold ? "On Hold" : "On Call";
+        helperText.textContent = currentDialpadState.isOnHold
+          ? "Call is on hold. Tap Hold to resume."
+          : "You are connected. Use Hold or Speaker as needed.";
+      } else if (currentDialpadState.dialedNumber.length > 0) {
+        statusPill.dataset.active = "false";
+        statusPill.textContent = "Ready";
+        helperText.textContent = "Press Call to connect or erase to edit the number.";
+      } else {
+        statusPill.dataset.active = "false";
+        statusPill.textContent = "Ready";
+        helperText.textContent = "Tap digits or choose a contact to start dialing.";
+      }
+    };
+
+    const appendDigit = (digit) => {
+      currentDialpadState.dialedNumber = `${currentDialpadState.dialedNumber}${digit}`;
+      dispatchDialpadEvent(digit);
+      updateUI();
+    };
+
+    const eraseDigit = () => {
+      if (!currentDialpadState.dialedNumber) return;
+      currentDialpadState.dialedNumber = currentDialpadState.dialedNumber.slice(0, -1);
+      updateUI();
+    };
+
+    const resetDialer = () => {
+      currentDialpadState.dialedNumber = "";
+      currentDialpadState.isOnCall = false;
+      currentDialpadState.isOnHold = false;
+      updateUI();
+    };
+
+    beaverPhoneConfig.dialpad.forEach((item) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "dialpad-key";
+      btn.textContent = item.label;
+      if (item.subtext) {
+        const sub = document.createElement("span");
+        sub.textContent = item.subtext;
+        btn.appendChild(sub);
+      }
+      btn.addEventListener("click", () => appendDigit(item.label));
+      dialpadEl.appendChild(btn);
+    });
+
+    callBtn.addEventListener("click", () => {
+      if (!currentDialpadState.isOnCall && currentDialpadState.dialedNumber.length === 0) {
+        helperText.textContent = "Enter a number or choose a contact first.";
+        return;
+      }
+      currentDialpadState.isOnCall = !currentDialpadState.isOnCall;
+      if (!currentDialpadState.isOnCall) {
+        currentDialpadState.isOnHold = false;
+      }
+      updateUI();
+    });
+
+    holdBtn.addEventListener("click", () => {
+      if (!currentDialpadState.isOnCall) return;
+      currentDialpadState.isOnHold = !currentDialpadState.isOnHold;
+      updateUI();
+    });
+
+    speakerBtn.addEventListener("click", () => {
+      currentDialpadState.isSpeakerEnabled = !currentDialpadState.isSpeakerEnabled;
+      updateUI();
+    });
+
+    eraseBtn.addEventListener("click", () => {
+      if (currentDialpadState.dialedNumber.length === 0) {
+        helperText.textContent = "Nothing to erase.";
+        return;
+      }
+      eraseDigit();
+    });
+
+    clearBtn.addEventListener("click", resetDialer);
+
+    composerInput.addEventListener("input", (event) => {
+      const { value } = event.target;
+      currentDialpadState.dialedNumber = value.replace(/[^0-9*#]/g, "");
+      updateUI();
+    });
+
+    composerInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        callBtn.click();
+      } else if (event.key === "Backspace" && event.metaKey) {
+        resetDialer();
+      }
+    });
+
+    beaverPhoneConfig.contacts.forEach((contact) => {
+      const card = document.createElement("article");
+      card.className = "extension-card";
+      card.innerHTML = `
+        <div class="badge">${contact.extension.slice(0, 2)}</div>
+        <div>
+          <h3>${contact.name}</h3>
+          <div class="subtitle">${contact.subtitle}</div>
+          <div class="details">${contact.details}</div>
+        </div>
+        <div class="extension">Ext. ${contact.extension}</div>
+      `;
+      card.addEventListener("click", () => {
+        currentDialpadState.dialedNumber = contact.extension;
+        currentDialpadState.isOnCall = true;
+        currentDialpadState.isOnHold = false;
+        dispatchDialpadEvent(contact.extension);
+        updateUI();
+      });
+      extensionList.appendChild(card);
+    });
+
+    if (beaverPhoneConfig.contacts.length === 0) {
+      const emptyState = document.createElement("p");
+      emptyState.className = "empty-hint";
+      emptyState.textContent = "No saved extensions yet.";
+      extensionList.appendChild(emptyState);
     }
+
+    updateUI();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the simple BeaverPhone stub with a full softphone dialpad experience
- add styling for a dark UI using BeaverPhone brand accent colours
- render contacts, dial actions, and stateful controls for call, hold, speaker, erase, and clear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de140d02a48325b11dca320a4c94fa