### PR TITLE
Improve BeaverPhone WebSocket logging and dispatcher

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -6,39 +6,67 @@ function connectWS() {
   ws = new WebSocket("ws://192.168.1.60:5001");
 
   ws.on("open", () => {
-    console.log("[BeaverPhone] Connecté au WS local Termux");
+    console.log("[BeaverPhone] Connected to local Termux WS");
   });
 
   ws.on("close", () => {
-    console.log("[BeaverPhone] WS fermé, reconnexion dans 5s...");
+    console.log("[BeaverPhone] WS closed, reconnecting in 5s…");
     setTimeout(connectWS, 5000);
   });
 
   ws.on("error", (err) => {
-    console.error("[BeaverPhone] Erreur WS:", err.message);
+    console.error("[BeaverPhone] WS error:", err.message);
   });
 
   ws.on("message", (msg) => {
-    console.log("[BeaverPhone] Réponse:", msg.toString());
+    const text = msg.toString();
+    try {
+      const data = JSON.parse(text);
+      console.log("[BeaverPhone] JSON Response:", data);
+    } catch (err) {
+      console.log("[BeaverPhone] Raw Response:", text);
+    }
   });
 }
+
+function sendPayload(action, data = {}) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    const payload = { type: action, ...data };
+    ws.send(JSON.stringify(payload));
+    console.log("[BeaverPhone] Sent:", payload);
+  } else {
+    console.warn("[BeaverPhone] WS not ready for:", action);
+  }
+}
+
+setInterval(() => {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: "ping" }));
+    console.log("[BeaverPhone] Sent keep-alive ping");
+  }
+}, 30000);
 
 connectWS();
 
 window.addEventListener("DOMContentLoaded", () => {
   window.addEventListener("beaverphone:dialpad", (event) => {
-    const dialpadEvent = event.detail;
+    const { action, number } = event.detail;
 
-    const payload = {
-      type: "dial",
-      number: dialpadEvent.number,
-    };
-
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(payload));
-      console.log("[BeaverPhone] Envoyé:", payload);
-    } else {
-      console.warn("[BeaverPhone] WS non prêt");
+    switch (action) {
+      case "dial":
+        sendPayload("dial", { number });
+        break;
+      case "hangup":
+        sendPayload("hangup");
+        break;
+      case "dtmf":
+        sendPayload("dtmf", { digit: number });
+        break;
+      case "clear":
+        sendPayload("clear");
+        break;
+      default:
+        console.warn("[BeaverPhone] Unknown action:", action);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable payload dispatcher for BeaverPhone dialpad events
- implement periodic ping keepalive to prevent idle disconnects
- enhance WebSocket logging with JSON parsing and keep-alive reporting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df179c51608325bf6be0f7c484fe5a