### PR TITLE
Fix asset paths after moving HTML into page folder

### DIFF
--- a/page/beaverphone.html
+++ b/page/beaverphone.html
@@ -624,10 +624,10 @@
       { label: "*" }, { label: "0", subtext: "+" }, { label: "#" },
     ],
     contacts: [
-      { name: "Ontario Provincial Police", subtitle: "Internal line", details: "Office 101", extension: "1201", image: "contact/Police.png" },
-      { name: "SPCA Niagara", subtitle: "Paws Law", details: "Office 3434", extension: "3434", image: "contact/SPCA.png" },
+      { name: "Ontario Provincial Police", subtitle: "Internal line", details: "Office 101", extension: "1201", image: "../contact/Police.png" },
+      { name: "SPCA Niagara", subtitle: "Paws Law", details: "Office 3434", extension: "3434", image: "../contact/SPCA.png" },
       { name: "Mom", subtitle: "Mom", details: "Complaints Office", extension: "22", image: null },
-      { name: "Services Ontario", subtitle: "Government of Ontario", details: "Desktop *1345", extension: "1345", image: "contact/ontario.svg" },
+      { name: "Services Ontario", subtitle: "Government of Ontario", details: "Desktop *1345", extension: "1345", image: "../contact/ontario.svg" },
     ],
     dialpadEventKey: BEAVERPHONE_DIALPAD_EVENT_KEY,
   };

--- a/page/menu.html
+++ b/page/menu.html
@@ -200,7 +200,7 @@
     <section class="menu">
       <article class="card" onclick="location.href='beaverphone.html'">
         <div class="icon" aria-hidden="true">
-          <img src="icon/phone.svg" alt="" />
+          <img src="../icon/phone.svg" alt="" />
         </div>
         <h2 data-i18n="beaverphoneTitle">BeaverPhone (local)</h2>
         <p data-i18n="beaverphoneBody">Passez des appels internes ou externes en toute simplicité grâce à notre téléphone virtuel.</p>
@@ -208,7 +208,7 @@
 
       <article class="card" onclick="location.href='https://rgbeavernet.ca'">
         <div class="icon" aria-hidden="true">
-          <img src="icon/beaver.png" alt="" />
+          <img src="../icon/beaver.png" alt="" />
         </div>
         <h2 data-i18n="beavernetTitle">BeaverNet.ca (cloud)</h2>
         <p data-i18n="beavernetBody">Accédez à la suite de services infonuagiques BeaverNet pour gérer vos activités en ligne.</p>


### PR DESCRIPTION
## Summary
- update menu icons to use correct relative path from the new page directory
- correct beaverphone extension avatar paths to point to the shared contact assets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e183ca666c8325976e533322d53b3c