### PR TITLE
Use IPC to handle overlay navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,13 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 
+let win;
+
+const menuPath = path.join(__dirname, 'page', 'menu.html');
+const menuUrl = `file://${menuPath.replace(/\\/g, '/')}`;
+
 function createWindow() {
-  const win = new BrowserWindow({
+  win = new BrowserWindow({
     kiosk: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -10,9 +15,6 @@ function createWindow() {
       nodeIntegration: false,
     }
   });
-
-  const menuPath = path.join(__dirname, 'page', 'menu.html');
-  const menuUrl = `file://${menuPath.replace(/\\/g, '/')}`;
 
   // Démarrer sur le menu local
   win.loadFile(menuPath);
@@ -54,7 +56,9 @@ function createWindow() {
           boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
         });
         btn.addEventListener('click', () => {
-          window.location.href = MENU_URL;
+          if (window.electronAPI?.goHome) {
+            window.electronAPI.goHome();
+          }
         });
         document.body.appendChild(btn);
       }
@@ -65,6 +69,12 @@ function createWindow() {
     });
   });
 }
+
+ipcMain.on('go-home', () => {
+  if (win) {
+    win.loadFile(menuPath);
+  }
+});
 
 app.whenReady().then(createWindow);
 

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,9 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  goHome: () => ipcRenderer.send('go-home'),
+});
+
 console.log("✅ preload loaded");
 
 const WS_STATUS_EVENT_KEY = "beaverphone:ws-status";


### PR DESCRIPTION
## Summary
- expose an electronAPI bridge in the preload script so renderer code can request a return to the menu
- listen for the go-home IPC message in the main process and reload the kiosk menu page
- update the injected back button to call the new bridge instead of directly touching window.location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e188bdf3c0832594887945033f1a71