### PR TITLE
Add zoom keyboard shortcuts

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,10 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
 const path = require('path');
 
 let win;
+const ZOOM_STEP = 0.5;
+const MIN_ZOOM_LEVEL = -5;
+const MAX_ZOOM_LEVEL = 5;
 
 const menuPath = path.join(__dirname, 'page', 'menu.html');
 const menuUrl = `file://${menuPath.replace(/\\/g, '/')}`;
@@ -70,14 +73,42 @@ function createWindow() {
   });
 }
 
+function adjustZoom(delta) {
+  if (!win) return;
+
+  const { webContents } = win;
+  const current = webContents.getZoomLevel();
+  const next = Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, current + delta));
+  webContents.setZoomLevel(next);
+}
+
+function registerZoomShortcuts() {
+  const shortcuts = [
+    { accelerator: 'CommandOrControl+=', delta: ZOOM_STEP },
+    { accelerator: 'CommandOrControl+Shift+=', delta: ZOOM_STEP },
+    { accelerator: 'CommandOrControl+-', delta: -ZOOM_STEP },
+  ];
+
+  shortcuts.forEach(({ accelerator, delta }) => {
+    globalShortcut.register(accelerator, () => adjustZoom(delta));
+  });
+}
+
 ipcMain.on('go-home', () => {
   if (win) {
     win.loadFile(menuPath);
   }
 });
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  createWindow();
+  registerZoomShortcuts();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });


### PR DESCRIPTION
## Summary
- register global shortcuts for Ctrl/Cmd with plus and minus to control zoom level
- constrain zoom adjustments and clean up shortcuts on app quit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18a1d64288325b26a9e0a8994a513